### PR TITLE
迁移Qt版本到Qt6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ CMakeLists.txt.user*
 .vscode
 *.code-workspace
 *.zip
+
+# Build
+build/

--- a/dogcom.cpp
+++ b/dogcom.cpp
@@ -27,7 +27,7 @@ void DogCom::FillConfig(QString a, QString p, QString m)
 	mac_addr = m;
 }
 
-void DogCom::print_packet(const char msg[], const unsigned char *packet, int length)
+void DogCom::print_packet(const char* msg, const unsigned char *packet, int length)
 {
 	if (!log)
 		return;

--- a/dogcom.cpp
+++ b/dogcom.cpp
@@ -45,7 +45,7 @@ void DogCom::run()
 	//    qDebug()<<"account:"<<account;
 	//    qDebug()<<"password:"<<password;
 	//    qDebug()<<"mac_addr:"<<mac_addr;
-	qDebug() << endl;
+    qDebug() << Qt::endl;
 	qDebug() << "Start dogcoming...";
 	// 后台登录维持连接的线程
 	srand((unsigned int)time(nullptr));
@@ -54,7 +54,7 @@ void DogCom::run()
 	{
         skt.init();
 	}
-	catch (DogcomSocketException e)
+    catch (DogcomSocketException& e)
 	{
 		qCritical() << "dogcom socket init error"
 					<< " msg: " << e.what();

--- a/main.cpp
+++ b/main.cpp
@@ -72,7 +72,7 @@ int main(int argc, char *argv[])
 #endif
 
 	SingleApplication::setQuitOnLastWindowClosed(false);
-	SingleApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+    // SingleApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
 
 	qDebug() << "...main...";
 
@@ -82,7 +82,9 @@ int main(int argc, char *argv[])
 	a.setFont(font);
 
 	QTranslator translator;
-	translator.load(":/ts/DrCOM_zh_CN.qm");
+    if (!translator.load(":/ts/DrCOM_zh_CN.qm")) {
+        qWarning() << "Failed to load translation file!";
+    }
 	a.installTranslator(&translator);
 
     MainWindow w(&a);

--- a/main.cpp
+++ b/main.cpp
@@ -50,7 +50,7 @@ void LogMsgOutput(QtMsgType type,
 	QFile file(dir.path() + QString("/logs/log%1.lgt").arg(timePoint));
 	file.open(QIODevice::WriteOnly | QIODevice::Append);
 	QTextStream out(&file);
-	out << log << endl;
+    out << log << Qt::endl;
 	file.close();
 
 	// 释放锁

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -6,7 +6,7 @@
 #include <QDebug>
 #include <QMessageBox>
 #include <QValidator>
-#include <QRegExp>
+#include <QRegularExpression>
 #include <QSettings>
 #include <QWindow>
 #include "constants.h"
@@ -15,6 +15,7 @@
 #include <QUrl>
 #include <QCloseEvent>
 #include <QProcess>
+#include <QTimer>
 
 MainWindow::MainWindow(SingleApplication *parentApp, QWidget *parent) :
     QDialog(parent),
@@ -94,7 +95,7 @@ MainWindow::MainWindow(SingleApplication *parentApp, QWidget *parent) :
 		this, &MainWindow::HandleIpAddress);
 
 	// 验证手动输入的mac地址
-	macValidator = new QRegExpValidator(QRegExp("[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}"));
+    macValidator = new QRegularExpressionValidator(QRegularExpression("[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}"), this);
 	ui->lineEditMAC->setValidator(macValidator);
 
 	// 尚未登录 不可注销
@@ -158,8 +159,8 @@ void MainWindow::RestartDrcom()
 void MainWindow::QuitDrcom()
 {
 	// 退出之前恢复重试计数
-	QSettings s(SETTINGS_FILE_NAME);
-	s.setValue(ID_RESTART_TIMES, 0);
+    QSettings s(SETTINGS_FILE_NAME, QSettings::IniFormat);
+    s.setValue(ID_RESTART_TIMES, 0);
 	qDebug() << "reset restartTimes";
 	qDebug() << "QuitDrcom";
 
@@ -168,7 +169,8 @@ void MainWindow::QuitDrcom()
     if(CURR_STATE==STATE_ONLINE)
         dogcomController->LogOut();
     else if(CURR_STATE==STATE_OFFLINE)
-        qApp->quit();
+        // qApp->quit();
+        QTimer::singleShot(0, qApp, SLOT(quit()));
     else if(CURR_STATE==STATE_LOGGING)
         ;// 正在登录时候退出，假装没看到，不理
 

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -152,8 +152,8 @@ void MainWindow::RestartDrcom()
         QProcess::startDetached(qApp->arguments()[0], qApp->arguments());
         qDebug() << "Restart done.";
     }
-    else if(CURR_STATE==STATE_LOGGING)
-        ;// 正在登录时候退出，假装没看到，不理
+    // else if(CURR_STATE==STATE_LOGGING)
+    // 正在登录时候退出，假装没看到，不理
 }
 
 void MainWindow::QuitDrcom()
@@ -171,8 +171,8 @@ void MainWindow::QuitDrcom()
     else if(CURR_STATE==STATE_OFFLINE)
         // qApp->quit();
         QTimer::singleShot(0, qApp, SLOT(quit()));
-    else if(CURR_STATE==STATE_LOGGING)
-        ;// 正在登录时候退出，假装没看到，不理
+    // else if(CURR_STATE==STATE_LOGGING)
+    // 正在登录时候退出，假装没看到，不理
 
     // qApp->quit()调用放到了注销响应那块
 }

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -3,7 +3,7 @@
 
 #include <QDialog>
 #include <QSettings>
-#include <QRegExpValidator>
+#include <QRegularExpressionValidator>
 #include <dogcomcontroller.h>
 #include <QSystemTrayIcon>
 #include "singleapplication.h"
@@ -61,7 +61,7 @@ private:
 	// 用于在未登录时关闭窗口就退出
 	int CURR_STATE;
 
-	QRegExpValidator *macValidator;
+    QValidator *macValidator;
 	DogcomController *dogcomController;
 
 	// 设置托盘中的注销按钮的可用性

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>242</width>
+    <width>250</width>
     <height>237</height>
    </rect>
   </property>
@@ -47,7 +47,7 @@
              </font>
             </property>
             <property name="echoMode">
-             <enum>QLineEdit::Password</enum>
+             <enum>QLineEdit::EchoMode::Password</enum>
             </property>
            </widget>
           </item>
@@ -60,7 +60,7 @@
              <string>MAC</string>
             </property>
             <property name="alignment">
-             <set>Qt::AlignCenter</set>
+             <set>Qt::AlignmentFlag::AlignCenter</set>
             </property>
            </widget>
           </item>
@@ -70,7 +70,7 @@
              <string>Account</string>
             </property>
             <property name="alignment">
-             <set>Qt::AlignCenter</set>
+             <set>Qt::AlignmentFlag::AlignCenter</set>
             </property>
            </widget>
           </item>
@@ -86,7 +86,7 @@
              <string>Password</string>
             </property>
             <property name="alignment">
-             <set>Qt::AlignCenter</set>
+             <set>Qt::AlignmentFlag::AlignCenter</set>
             </property>
            </widget>
           </item>
@@ -137,7 +137,7 @@
            <string>Your IP address will be shown here</string>
           </property>
           <property name="alignment">
-           <set>Qt::AlignHCenter|Qt::AlignTop</set>
+           <set>Qt::AlignmentFlag::AlignHCenter|Qt::AlignmentFlag::AlignTop</set>
           </property>
          </widget>
         </item>

--- a/singleinstance/singleapplication.cpp
+++ b/singleinstance/singleapplication.cpp
@@ -26,6 +26,8 @@
 #include <QtCore/QByteArray>
 #include <QtCore/QSharedMemory>
 
+#include <cstdlib>
+
 #include "singleapplication.h"
 #include "singleapplication_p.h"
 
@@ -75,7 +77,7 @@ SingleApplication::SingleApplication( int &argc, char *argv[], bool allowSeconda
     }
 
     InstancesInfo* inst = static_cast<InstancesInfo*>( d->memory->data() );
-    QTime time;
+    QElapsedTimer time;
     time.start();
 
     // Make sure the shared memory block is initialised and in consistent state
@@ -92,8 +94,8 @@ SingleApplication::SingleApplication( int &argc, char *argv[], bool allowSeconda
         d->memory->unlock();
 
         // Random sleep here limits the probability of a collision between two racing apps
-        qsrand( QDateTime::currentMSecsSinceEpoch() % std::numeric_limits<uint>::max() );
-        QThread::sleep( 8 + static_cast <unsigned long>( static_cast <float>( qrand() ) / RAND_MAX * 10 ) );
+        srand( QDateTime::currentMSecsSinceEpoch() % std::numeric_limits<uint>::max() );
+        QThread::sleep( 8 + static_cast <unsigned long>( static_cast <float>( rand() ) / RAND_MAX * 10 ) );
     }
 
     if( inst->primary == false) {

--- a/singleinstance/singleapplication_p.cpp
+++ b/singleinstance/singleapplication_p.cpp
@@ -83,7 +83,7 @@ SingleApplicationPrivate::~SingleApplicationPrivate()
 void SingleApplicationPrivate::genBlockServerName()
 {
     QCryptographicHash appData( QCryptographicHash::Sha256 );
-    appData.addData( "SingleApplication", 17 );
+    appData.addData( "SingleApplication");
     appData.addData( SingleApplication::app_t::applicationName().toUtf8() );
     appData.addData( SingleApplication::app_t::organizationName().toUtf8() );
     appData.addData( SingleApplication::app_t::organizationDomain().toUtf8() );
@@ -217,7 +217,7 @@ void SingleApplicationPrivate::connectToPrimary( int msecs, ConnectionType conne
         writeStream << blockServerName.toLatin1();
         writeStream << static_cast<quint8>(connectionType);
         writeStream << instanceNumber;
-        quint16 checksum = qChecksum(initMsg.constData(), static_cast<quint32>(initMsg.length()));
+        quint16 checksum = qChecksum(QByteArrayView(initMsg.constData(), static_cast<quint32>(initMsg.length())));
         writeStream << checksum;
 
         // The header indicates the message length that follows
@@ -239,8 +239,8 @@ void SingleApplicationPrivate::connectToPrimary( int msecs, ConnectionType conne
 quint16 SingleApplicationPrivate::blockChecksum()
 {
     return qChecksum(
-       static_cast <const char *>( memory->data() ),
-       offsetof( InstancesInfo, checksum )
+        QByteArrayView((static_cast <const char *>(memory->data())),
+         offsetof( InstancesInfo, checksum ))
    );
 }
 
@@ -365,7 +365,7 @@ void SingleApplicationPrivate::readInitMessageBody( QLocalSocket *sock )
     quint16 msgChecksum = 0;
     readStream >> msgChecksum;
 
-    const quint16 actualChecksum = qChecksum( msgBytes.constData(), static_cast<quint32>( msgBytes.length() - sizeof( quint16 ) ) );
+    const quint16 actualChecksum = qChecksum( QByteArrayView(msgBytes.constData(), static_cast<quint32>( msgBytes.length() - sizeof( quint16 ) )) );
 
     bool isValid = readStream.status() == QDataStream::Ok &&
                    QLatin1String(latin1Name) == blockServerName &&


### PR DESCRIPTION
# 由于Qt5在2023年5月26日已终止支持，LTS版本也于2025年5月26日终止支持，将该项目迁移到Qt6以便于后续的开发和使用

迁移到Qt6后，由于一些旧特性的移除和变化，对代码作了以下修改：
- Qt5中的```<QRegExpValidator>```模块在Qt6中被移除，已改用```<QRegularExpressionValidator>```
- Qt6移除了```qsrand``` ```qrand```等随机数函数，为尽量减少修改，改用了C语言的```srand``` ```rand```
- Qt6移除了```QTime::start()```，程序中的计时改用```QElapsedTimer```实现
- 原来的退出函数：

```cpp
#define qApp (static_cast<QApplication *>(QCoreApplication::instance()))

void MainWindow::QuitDrcom()
{
    // 退出之前恢复重试计数
    // QSettings s(SETTINGS_FILE_NAME, QSettings::IniFormat);
    // s.setValue(ID_RESTART_TIMES, 0);
    qDebug() << "reset restartTimes";
    qDebug() << "QuitDrcom";

    // TODO : release socket
    bQuit=true;
    if(CURR_STATE==STATE_ONLINE)
        dogcomController->LogOut();
    else if(CURR_STATE==STATE_OFFLINE)
        qApp->quit();
    else if(CURR_STATE==STATE_LOGGING)
        ;// 正在登录时候退出，假装没看到，不理

    // qApp->quit()调用放到了注销响应那块
}
```

其中的```qApp->quit();```在Qt6会导致递归调用，现改用```QTimer::singleShot(0, qApp, SLOT(quit()));```延迟退出解决此问题

以下是由于旧函数弃用导致的编译时警告，也进行了修改：
- Qt6中已默认开启了高分辨率支持，```Qt::AA_EnableHighDpiScaling```属性已弃用
- Qt6弃用了```QCryptographicHash::addData(const char* data, qsizetype length)```，现将长度删除，不传入参数，字符串常量将直接作为```QByteArray```处理
- qCheckSum函数参数列表变化，现将传入的参数先构造为```QByteArrayView```

现在，你可以自行通过Qt6编译该项目，或由于原作者已长期不维护该项目，你可以选择前往我的分支 <https://github.com/KnCRJVirX/drcom-jlu-qt/> 体验新的特性（可选不弹出校园网之窗、密码加密存储等）